### PR TITLE
resolve memory leak and fix stop() promise handler

### DIFF
--- a/lib/ws.js
+++ b/lib/ws.js
@@ -67,7 +67,7 @@ Webmo.prototype.rotateTo = function rotateTo (target, absRange, speed) {
 
   // XXX: reject
   return Q.Promise(function (resolve, reject) {
-    this._ev.on('notice', function (data) {
+    this._ev.once('notice', function (data) {
       if (data.msg === 'done' && data.func === 'rotateTo') {
         resolve(data)
       }
@@ -81,7 +81,7 @@ Webmo.prototype.rotateBy = function rotateBy (diff, speed) {
 
   // XXX: reject
   return Q.Promise(function (resolve, reject) {
-    this._ev.on('notice', function (data) {
+    this._ev.once('notice', function (data) {
       if (data.msg === 'done' && data.func === 'rotateBy') {
         resolve(data)
       }
@@ -110,8 +110,8 @@ Webmo.prototype.stop = function stop (smooth, lock) {
 
   // XXX: reject
   return Q.Promise(function (resolve, reject) {
-    this._ev.on('notice', function (data) {
-      if (data.msg === 'done' && data.func === 'stop') {
+    this._ev.once('notice', function (data) {
+      if (data.msg === 'stop rotating') {
         resolve(data)
       }
     })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webmo-client",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "A javascript library for webmo",
   "keywords": ["Webmo", "WoT", "IoT","Cidre", "CidreIxD"],
   "homepage": "https://github.com/cidreixd/webmo-library-javascript",


### PR DESCRIPTION
- use EventEmitter.once instead of on to remove temporary event listeners
- notice message for stop() is not { msg: 'done', func: 'stop' } but { msg: 'stop rotating' }